### PR TITLE
Feature custom tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ This extension contributes the following settings:
   When enabled, will include the async tag.  
   Disable to exclude it from the generated JSDoc.  
   Default: `true`
+- `jsdoc-generator.customTags`:  
+  When configured, will add custom tags by default.  
+  Example:
+  ```javascript
+  "jsdoc-generator.customTags": [
+    {
+      "tag": "example",
+      "placeholder": "Example placeholder"
+    },
+  ]
+  ```
 
 ---
 
@@ -79,6 +90,10 @@ Some non [everyday types](https://www.typescriptlang.org/docs/handbook/2/everyda
 ---
 
 ## Release Notes
+
+### [1.3.0](https://github.com/Nyphet/jsdoc-generator/releases/tag/v1.3.0)
+
+Added a new setting option to create custom tags.
 
 ### [1.2.0](https://github.com/Nyphet/jsdoc-generator/releases/tag/v1.2.0)
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Automatic JSDoc generator for TypeScript and JavaScript.",
   "publisher": "crystal-spider",
   "icon": "jsdoc-generator.png",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "engines": {
     "vscode": "^1.57.0"
   },

--- a/package.json
+++ b/package.json
@@ -86,6 +86,25 @@
           "type": "boolean",
           "default": "true",
           "description": "Whether to include the async tag or not."
+        },
+        "jsdoc-generator.customTags": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "tag": {
+                "type": "string",
+                "description": "Tag name"
+              },
+              "placeholder": {
+                "type": "string",
+                "description": "Placeholder text",
+                "default": ""
+              }
+            }
+          },
+          "default": [],
+          "description": "Set custom tags."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,8 @@ type ConfigurationItem =
   'descriptionForConstructors' |
   'functionVariablesAsFunctions' |
   'includeExport' |
-  'includeAsync';
+  'includeAsync' |
+  'customTags';
 
 /**
  * JSDoc Autocompletion item.


### PR DESCRIPTION
This adds custom tags configuration, to facilitate repeated use of tags that are not placed by default by jsdoc-generator like @see

![image](https://github.com/Nyphet/jsdoc-generator/assets/46272966/a0c976ed-8364-4103-80a3-a6e177e863a8)
 
![image](https://github.com/Nyphet/jsdoc-generator/assets/46272966/b771895b-2b6c-4aa7-a2e1-4fc5d58091e9)
